### PR TITLE
Parse multiple lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# WMIC
+
+Node module to interact with the windows WMIC utility.
+
+## Usage
+
+### wmic.get_value(section, value, conditions, callback)
+
+Returns a single value from wmic, for example to get the hostname:
+
+```javascript
+wmic.get_value('computersystem', 'name', null, function(err, value){
+  console.log(value) // Your Hostname
+})
+```
+
+### wmic.get_values(section, value, conditions, callback)
+
+Returns an array of values from wmic, for example to list hard drives:
+
+```javascript
+wmic.get_values('logicaldisk', 'name, volumename', null, function(err, values){
+  console.dir(values) // An array of disks
+})
+```

--- a/index.js
+++ b/index.js
@@ -78,10 +78,7 @@ var parse_list = function(data){
 var parse_values = function(out){
 
   var arr = [];
-  var data = out.toString().trim().split('\n')
-               .map(function(line){
-                 return line.trim().split(/\s+/);
-               });
+  var data = buildDataArray(out);
 
   var keys = data[0];
   data.forEach(function(k, i){
@@ -97,6 +94,41 @@ var parse_values = function(out){
   });
 
   return arr;
+}
+
+function buildDataArray(rawInput){
+  var lines = rawInput.toString().trim().split('\n');
+  var data = [];
+  var keys = [];
+
+  var linePattern = /(\S*?\s\s+)/g;
+  var match;
+
+  while ((match = linePattern.exec(lines[0])) !== null) {
+    if (match.index === linePattern.lastIndex) {
+        linePattern.lastIndex++;
+    }
+
+    var key = {};
+
+    key.string = match[0].trim();
+    key.startPoint = lines[0].indexOf(key.string);
+    key.keyLength = match[0].length;
+
+    keys.push(key);
+  }
+
+  lines.forEach(function(line, index){
+    var lineData = [];
+
+    keys.forEach(function(key, jndex){
+      lineData.push(line.substr(key.startPoint, key.keyLength).trim());
+    })
+
+    data.push(lineData);
+  })
+
+  return data;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -99,13 +99,6 @@ var parse_values = function(out){
   return arr;
 }
 
-function returnOne(data){
-  data[0].forEach(function(k, i) {
-    if (data[1] && data[1][i])
-      obj[k] = data[1][i];
-  })
-}
-
 /**
  * Run the wmic command provided.
  *

--- a/index.js
+++ b/index.js
@@ -77,18 +77,33 @@ var parse_list = function(data){
 
 var parse_values = function(out){
 
-  var obj = {};
+  var arr = [];
   var data = out.toString().trim().split('\n')
                .map(function(line){
                  return line.trim().split(/\s+/);
                });
 
+  var keys = data[0];
+  data.forEach(function(k, i){
+    if(k != keys){
+      var obj = {};
+
+      k.forEach(function(l, j){
+        obj[keys[j]] = l
+      })
+
+      arr.push(obj);
+    }
+  });
+
+  return arr;
+}
+
+function returnOne(data){
   data[0].forEach(function(k, i) {
     if (data[1] && data[1][i])
       obj[k] = data[1][i];
   })
-
-  return obj;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
   },
   "author": "",
   "license": "ISC",
-  "readme": "ERROR: No README data found!"
+  "readme": "ERROR: No README data found!",
+  "devDependencies": {
+    "mocha": "^2.2.4",
+    "should": "^6.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "author": "",
   "license": "ISC",
-  "readme": "ERROR: No README data found!",
   "devDependencies": {
     "mocha": "^2.2.4",
     "should": "^6.0.1"

--- a/test/wmic.js
+++ b/test/wmic.js
@@ -1,0 +1,36 @@
+wmic = require('../index')
+should = require('should')
+
+describe('wmic', function(){
+  describe('#values()', function(){
+    it('should handle values with spaces in', function(done){
+      // This test assumes that your first network card has a space in its name, it should...
+
+      wmic.get_values('nicconfig', 'description, ipaddress', null, function(err, values){
+        values[0].Description.indexOf(' ').should.not.equal(-1)
+        done()
+      })
+    })
+
+    it('should return multiple values', function(done){
+      // This test assumes you have more than one network card (you usually have some virtual ones)
+
+      wmic.get_values('nicconfig', 'description, ipaddress', null, function(err, values){
+        values.length.should.not.equal(1)
+        done()
+      })
+    })
+
+    it('should set all the keys, not present ones to an empty sting', function(done){
+      // This test assumes that not every network card has an IP
+
+      wmic.get_values('nicconfig', 'description, ipaddress', null, function(err, values){
+        values.forEach(function(value, index){
+          value.Description.should.not.equal(undefined)
+          value.IPAddress.should.not.equal(undefined)
+        })
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This fixes the issue in #1 where `get_values()` returns a single reply instead of all of them.

```
wmic.get_values('logicaldisk', 'name, volumename', null, function(err, values) {
  console.log(err || values);
});
```

now returns

```
 [ { Name: 'C:', VolumeName: 'Windows' },
   { Name: 'L:' },
   { Name: 'R:' },
   { Name: 'S:' },
   { Name: 'T:' },
   { Name: 'U:' },
   { Name: 'V:' },
   { Name: 'W:' } ] }
```