### PR TITLE
Set Limit for concurrent workers to 100

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 /*
   wmic calls must always be serialised in windows, hence the use of async.queue
 */
-
+var MAX_WORKER_COUNT = 100;
 var spawn = require('child_process').spawn,
     exec  = require('child_process').exec,
     async = require('async'),
@@ -230,7 +230,7 @@ var queue = async.queue(function(cmd, cb) {
     }).join(',').replace(/^,/, '').replace(/,\s+$/, '').trim();
   }
 
-}, 100);
+}, MAX_WORKER_COUNT);
 
 exports.get_value = function(section, value, condition, cb){
   var cond = condition ? ' where "' + condition + '" ' : '';

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ var queue = async.queue(function(cmd, cb) {
     }).join(',').replace(/^,/, '').replace(/,\s+$/, '').trim();
   }
 
-});
+}, 100);
 
 exports.get_value = function(section, value, condition, cb){
   var cond = condition ? ' where "' + condition + '" ' : '';


### PR DESCRIPTION
Added a concurrent worker limit of 100 to allow multiple workers to be executed at once. 

100 ist a "feeling" Because Windows allows a maximum of 300 subprocesses being spawned by one process. Maybe it should be configurable later.