### PR TITLE
Update iconv-lite version to add more encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "async": "",
-    "iconv-lite": "^0.4.13"
+    "iconv-lite": "^0.5.0"
   },
   "author": "Tomás Pollak <tomas@forkhq.com>",
   "repository": {


### PR DESCRIPTION
Hi @tomas ,

**iconv-lite** one of the dependencies has been upgraded to the new version **"0.5.1"**. 
Add more encoding with other languages that are used with WMIC. It occurs when some client chose out of the encoding list from **"iconv-lite"** and invoke WMIC with out of encoding list.

Could you please merge this PR to update the version of dependency?

Your sincerely,
Tanandara
