### PR TITLE
On some machines (Chinese) the error message can appear twice in chcp…

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function buildDataArray(rawInput){
 }
 
 function get_encoding(stdout) {
-    var codePage = stdout.replace(/\n.*$/, '').replace(/\D/g, '');
+    var codePage = stdout.replace(/\n.*$/s, '').replace(/\D/g, '');
     return codePage;
 }
 


### PR DESCRIPTION
… output:

"�ϥΤ����r�X��: 950\r\n[0x7FFA4CC4E0A4] ANOMALY: use of REX.w is meaningless (default operand size is 64)\r\n[0x7FFA4CC4E0A4] ANOMALY: use of REX.w is meaningless (default operand size is 64)\r\n"

So need the extra "s" in regexp to get rid of them all.