### PR TITLE
Update index.js to remove reliance on cmd.exe

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
   wmic calls must always be serialised in windows, hence the use of async.queue
 */
 var MAX_WORKER_COUNT = 100;
-var spawn = require('child_process').spawn,
+var execFile = require('child_process').execfile,
     exec  = require('child_process').exec,
     async = require('async'),
     fs    = require('fs'),
@@ -181,7 +181,7 @@ var queue = async.queue(function(cmd, cb) {
         }
       },
       function(cb) {
-        var wm = spawn('wmic', splitter(cmd), opts),
+        var wm = execFile('wmic', splitter(cmd), opts),
           stdout = [],
           stderr = [];
 


### PR DESCRIPTION
Replaced the use of child_process.spawn with child_process.execFile to remove the reliance on cmd.exe. wmic.exe should now be called directly from the code rather than started inside a cmd.exe shell, which is more efficient and will work on hardened computers where cmd.exe is not available to standard users. Tested using the example commands in README.md and the particular command our software was calling, all of which work as expected.