### PR TITLE
fix: execfile is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
   wmic calls must always be serialised in windows, hence the use of async.queue
 */
 var MAX_WORKER_COUNT = 100;
-var execFile = require('child_process').execfile,
+var execFile = require('child_process').execFile,
     exec  = require('child_process').exec,
     async = require('async'),
     fs    = require('fs'),


### PR DESCRIPTION
There seems to be a typo (introduced by https://github.com/tomas/wmic/pull/17) in the require statement as `execfile` does not exist as per https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback and causes errors in our project(`execFile` is not a function)

I tested this change locally and it seems to solve our issue.